### PR TITLE
Configure pytest path without conftest

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+pythonpath = .

--- a/tests/test_responses.py
+++ b/tests/test_responses.py
@@ -1,0 +1,32 @@
+import json
+
+from api import responses
+
+
+def test_ok_with_query_returns_expected_json():
+    response = responses.OkWithQuery("select 1")
+
+    assert response.status_code == 200
+    assert json.loads(response.body.decode()) == {"query": "select 1"}
+
+
+def test_ok_returns_empty_json():
+    response = responses.Ok()
+
+    assert response.status_code == 200
+    assert json.loads(response.body.decode()) == {}
+
+
+def test_ok_list_serializes_items_to_strings():
+    response = responses.OkList([1, "two", 3.0], name="items")
+
+    assert response.status_code == 200
+    assert json.loads(response.body.decode()) == {"items": ["1", "two", "3.0"]}
+
+
+def test_bad_request_returns_error_payload():
+    error = ValueError("boom")
+    response = responses.BadRequest(error)
+
+    assert response.status_code == 400
+    assert json.loads(response.body.decode()) == {"error": "boom"}

--- a/tests/test_translator.py
+++ b/tests/test_translator.py
@@ -1,0 +1,20 @@
+from api import translator
+
+
+def test_dialects_includes_mysql():
+    dialect_names = translator.dialects()
+    assert "MySQL" in dialect_names
+
+
+def test_is_supported_dialect_true_for_known_dialect():
+    assert translator.is_supported_dialect("MySQL")
+    assert translator.is_supported_dialect("mysql")
+
+
+def test_is_supported_dialect_false_for_unknown_dialect():
+    assert not translator.is_supported_dialect("not_a_real_dialect")
+
+
+def test_translate_returns_expected_sql_list():
+    translated = translator.translate("select * from tbl", "mysql", "postgres")
+    assert translated == ["SELECT * FROM tbl"]


### PR DESCRIPTION
## Summary
- remove the pytest `conftest.py` sys.path shim
- set the repository root on `PYTHONPATH` via `pytest.ini` so tests still import project modules

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d18863693c8320ae7a5197a01840fe