### PR TITLE
Add schema-aware validation support

### DIFF
--- a/ui/src/common/ITranslationProvider.tsx
+++ b/ui/src/common/ITranslationProvider.tsx
@@ -21,6 +21,12 @@ interface ITranslationProvider
     AvailableDialects() : Promise<string[]>;
 
     /**
+     * Applies a schema definition, provided as a JSON document, to the
+     * translation backend. Passing an empty string clears the active schema.
+     */
+    SetSchema(schemaJson: string): Promise<void>;
+
+    /**
      * Transpiles the given code from one dialect to another.
      * 
      * @param {string} code - The code to be transpiled.

--- a/ui/src/components/schema-section.tsx
+++ b/ui/src/components/schema-section.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+
+interface SchemaSectionProps {
+  schema: string;
+  onSchemaChange: (value: string) => void;
+  error?: string | null;
+}
+
+const SchemaSection: React.FC<SchemaSectionProps> = ({
+  schema,
+  onSchemaChange,
+  error,
+}) => {
+  return (
+    <section className="mt-6" aria-label="Schema configuration">
+      <div className="flex flex-col gap-1 mb-2">
+        <h2 className="text-lg font-semibold text-dracula-pink">
+          Schema (JSON)
+        </h2>
+        <p className="text-sm text-dracula-comment">
+          Provide a mapping of tables to columns (optionally nested by database)
+          to enable SQLGlot schema-aware validation. Leave empty to disable type
+          checking.
+        </p>
+      </div>
+      <textarea
+        className="w-full min-h-[10rem] bg-dracula-selection/25 text-dracula-foreground border border-dracula-pink/40 rounded-md p-3 font-mono text-sm focus:outline-none focus:ring-2 focus:ring-dracula-pink/70"
+        value={schema}
+        onChange={(event) => onSchemaChange(event.target.value)}
+        placeholder='{ "my_table": { "id": "INT", "name": "TEXT" } }'
+        aria-label="Schema JSON definition"
+      />
+      {error ? (
+        <div className="text-sm text-dracula-red mt-2" role="alert">
+          {error}
+        </div>
+      ) : schema.trim() ? (
+        <p className="text-xs text-dracula-comment mt-2">
+          Schema applied. Column references will now be validated against the
+          provided definition.
+        </p>
+      ) : (
+        <p className="text-xs text-dracula-comment mt-2">
+          Example: {"{ \"sales\": { \"id\": \"INT\", \"amount\": \"DECIMAL\" } }"}
+        </p>
+      )}
+    </section>
+  );
+};
+
+export { SchemaSection };

--- a/ui/src/sqlglot-ts/PythonWASMProvider.tsx
+++ b/ui/src/sqlglot-ts/PythonWASMProvider.tsx
@@ -22,6 +22,17 @@ class PythonWASMProvider implements ITranslationProvider {
         return dialects?.dialects ?? [];
     }
 
+    public async SetSchema(schemaJson: string): Promise<void> {
+        if (!this.initialized) {
+            await this.Initialize();
+        }
+
+        await this.RunWithOutput<{ status: string }>(
+            SQLGlotPython.SetSchema,
+            { schema_json: schemaJson ?? "" }
+        );
+    }
+
     public async Transpile(
         code: string,
         dialect: string,

--- a/ui/src/sqlglot-ts/sqlglot_python.ts
+++ b/ui/src/sqlglot-ts/sqlglot_python.ts
@@ -21,6 +21,7 @@ const SQLGlotPython = {
     TranspileQuery: "transpile_query(source, in_dialect, out_dialect, pretty)",
     GetColumns: "get_columns(source, in_dialect)",
     GetJoins: "get_joins(source, in_dialect)",
+    SetSchema: "set_schema(schema_json)",
 };
 
 export { fetchPythonDeclarations };


### PR DESCRIPTION
## Summary
- add a schema editor section to the transpile view that stores JSON in local storage and syncs it with the translator backend
- extend the translation provider and WASM bridge to accept schema JSON and run SQLGlot optimizer-based validation before transpiling or analyzing queries
- cover the new schema flow with Python unit tests for successful validation and unknown-column failures

## Testing
- pytest
- npm test -- --watch=false *(fails: Jest cannot parse ESM exports from CodeMirror dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68d1905197d08320887b58dcb2b179a0